### PR TITLE
Update shifty from 1.1.2 to 1.2

### DIFF
--- a/Casks/shifty.rb
+++ b/Casks/shifty.rb
@@ -1,6 +1,6 @@
 cask "shifty" do
-  version "1.1.2"
-  sha256 "71daedf1504907ac1ba59f478978da1c50bd78ddce846f4c1cf967462a40753a"
+  version "1.2"
+  sha256 "111b1df97cf5cbca91f4130e6d68d409dbefeffa9fde5f5c92f30f712a7215e9"
 
   url "https://github.com/thompsonate/Shifty/releases/download/v#{version}/Shifty-#{version}.zip",
       verified: "github.com/thompsonate/Shifty/"


### PR DESCRIPTION
After making all changes to a cask, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.
